### PR TITLE
Release 5tratSmack 0.10.27 to MAIN

### DIFF
--- a/willitmod-dev-5tratsmack/docker-compose.yml
+++ b/willitmod-dev-5tratsmack/docker-compose.yml
@@ -187,7 +187,7 @@ services:
       - edge
 
   app:
-    image: ghcr.io/willitmod/5tratsmack-app:0.10.26
+    image: ghcr.io/willitmod/5tratsmack-app:0.10.27
     restart: unless-stopped
     depends_on:
       init_permissions:
@@ -196,7 +196,7 @@ services:
         condition: service_started
     environment:
       APP_ID: 5tratsmack
-      APP_VERSION: 0.10.26
+      APP_VERSION: 0.10.27
       APP_CHANNEL: MAIN
       APP_RELEASE_PHASE: RC1
       APP_PLATFORM: 5TRATUMOS
@@ -205,7 +205,7 @@ services:
       FIVETRAT_STORE_UPDATE_APP_ID: 5tratsmack
       FIVETRAT_STORE_UPDATE_CHANNEL: main
       FIVETRAT_INSTALL_REVISION: main-store
-      FIVETRAT_RELEASE_TAG: 0.10.26
+      FIVETRAT_RELEASE_TAG: 0.10.27
       FIVETRAT_OS_UPDATE_PROXY_BASE: http://host.docker.internal
       NETWORK_IP: "${NETWORK_IP}"
       BCH2_RPC_HOST: node-a

--- a/willitmod-dev-5tratsmack/umbrel-app.yml
+++ b/willitmod-dev-5tratsmack/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: willitmod-dev-5tratsmack
 category: altcoin
 name: 5tratSmack
-version: "0.10.26"
+version: "0.10.27"
 tagline: Home-miner 5TRAT node, wallet, solo pool and atomic trade lab
 description: >-
   Install and synchronize a complete 5TRAT node, create or restore an encrypted
@@ -10,9 +10,12 @@ description: >-
   use the atomic trade lab from one 5tratumOS app.
 
   This MAIN-channel Release Candidate has completed extended public-chain,
-  wallet, pool and trading tests. It includes the approved 5TRAT roundel,
-  tiered block-history seals and clearer infrastructure-contribution wording.
-  Back up both the mining wallet and trading recovery file before moving funds.
+  wallet, pool and trading tests. Version 0.10.27 adds the portable
+  browser-wallet bridge, clearer separation between mining electricity cost
+  and traded value, an in-app field guide, the latest named Blue, Pink and Gold
+  winners, and a strongest-proof Wall of Hash with one entry per personalised
+  coinbase name. Back up both the mining wallet and trading recovery file
+  before moving funds.
   The trade book uses the public
   Komodo DeFi Framework network through outbound peer connections; every atomic
   swap still requires the participating wallets to approve and settle it.


### PR DESCRIPTION
## What changed

- publishes 5tratSmack `0.10.27` to the MAIN Community Store
- points the app service at the native AMD64 and ARM64 `0.10.27` image
- keeps the MAIN Release Candidate channel and its existing verified runtime pins
- documents the portable wallet bridge, mining-cost clarity, field guide, latest tier winners and Wall of Hash

## Validation

- both image architectures are present in GHCR
- Compose configuration passed with the standalone validation overlay
- store metadata parses correctly
- application feature suite and live desktop/mobile checks passed
