### PR TITLE
Fix AxeBench 4.0.28 MAIN Umbrel recipe

### DIFF
--- a/willitmod-axebench/docker-compose.yml
+++ b/willitmod-axebench/docker-compose.yml
@@ -1,9 +1,9 @@
-﻿version: "3.7"
+version: "3.7"
 
 services:
   app_proxy:
     environment:
-      APP_HOST: willitmod-dev-axebench_server_1
+      APP_HOST: willitmod-axebench_server_1
       APP_PORT: 5000
 
   server:
@@ -22,4 +22,4 @@ networks:
   default:
     ipam:
       config:
-        - subnet: 172.31.51.0/24
+        - subnet: 172.31.50.0/24

--- a/willitmod-axebench/umbrel-app.yml
+++ b/willitmod-axebench/umbrel-app.yml
@@ -1,8 +1,8 @@
-﻿manifestVersion: 1
+manifestVersion: 1
 id: willitmod-axebench
 category: bitcoin
 name: AxeBench
-version: "4.0.28"
+version: "4.0.28-r1"
 tagline: Bitaxe fleet benchmarking and management
 icon: https://raw.githubusercontent.com/WillItMod/umbrel-community-store/main/willitmod-axebench/icon.png
 description: >-
@@ -32,6 +32,11 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 releaseNotes: >-
+  v4.0.28-r1:
+    - Restore the MAIN Umbrel proxy hostname so AxeBench opens correctly on port 5000.
+    - Restore the MAIN network subnet to avoid colliding with an installed DEV package.
+    - Keep the tested v4.0.28 Release Candidate application image unchanged.
+
   v4.0.28:
     - Promote the tested DEV build to the MAIN Community Store as a Release Candidate.
     - Align the visible UI and backend version markers with the release image.


### PR DESCRIPTION
## Summary
- restore the MAIN AxeBench app-proxy hostname
- restore the former MAIN subnet so MAIN does not collide with DEV
- publish the recipe correction as 4.0.28-r1 without changing the tested application image
- remove accidental UTF-8 BOMs from the promoted YAML

## Verification
- v4.0.28 exposes native amd64 and arm64 manifests
- ARM64 image starts on 0.0.0.0:5000 and returns HTTP 200
- reproduced Docker subnet-overlap failure with the promoted DEV subnet
- reproduced DNS failure for the promoted DEV proxy hostname
- corrected MAIN hostname returns HTTP 200 over the restored MAIN network
- both YAML files parse successfully