### PR TITLE
Release AxeBench 4.0.29 MAIN packaging fix

### DIFF
--- a/willitmod-axebench/docker-compose.yml
+++ b/willitmod-axebench/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 5000
 
   server:
-    image: ghcr.io/willitmod/axebench:v4.0.28
+    image: ghcr.io/willitmod/axebench:v4.0.29
     restart: on-failure
     stop_grace_period: 30s
     init: true

--- a/willitmod-axebench/umbrel-app.yml
+++ b/willitmod-axebench/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: willitmod-axebench
 category: bitcoin
 name: AxeBench
-version: "4.0.28-r1"
+version: "4.0.29"
 tagline: Bitaxe fleet benchmarking and management
 icon: https://raw.githubusercontent.com/WillItMod/umbrel-community-store/main/willitmod-axebench/icon.png
 description: >-
@@ -32,6 +32,11 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 releaseNotes: >-
+  v4.0.29:
+    - Publish a new multi-architecture image tag so Umbrel performs the update.
+    - Restore the MAIN proxy hostname so AxeBench opens correctly on port 5000.
+    - Restore the MAIN network subnet to avoid colliding with an installed DEV package.
+
   v4.0.28-r1:
     - Restore the MAIN Umbrel proxy hostname so AxeBench opens correctly on port 5000.
     - Restore the MAIN network subnet to avoid colliding with an installed DEV package.


### PR DESCRIPTION
## Summary
- bump the MAIN Umbrel package to 4.0.29
- point MAIN at the new ghcr.io/willitmod/axebench:v4.0.29 image tag
- retain the corrected MAIN proxy hostname and subnet from 4.0.28-r1

## Verification
- v4.0.29 is publicly pullable
- v4.0.29 includes linux/amd64 and linux/arm64
- ARM64 container starts and returns HTTP 200 on port 5000
- package and compose YAML parse successfully