### PR TITLE
Release 5tratSmack 0.10.28 routing hotfix to MAIN

### DIFF
--- a/willitmod-dev-5tratsmack/docker-compose.yml
+++ b/willitmod-dev-5tratsmack/docker-compose.yml
@@ -187,7 +187,7 @@ services:
       - edge
 
   app:
-    image: ghcr.io/willitmod/5tratsmack-app:0.10.27
+    image: ghcr.io/willitmod/5tratsmack-app:0.10.28
     restart: unless-stopped
     depends_on:
       init_permissions:
@@ -196,7 +196,7 @@ services:
         condition: service_started
     environment:
       APP_ID: 5tratsmack
-      APP_VERSION: 0.10.27
+      APP_VERSION: 0.10.28
       APP_CHANNEL: MAIN
       APP_RELEASE_PHASE: RC1
       APP_PLATFORM: 5TRATUMOS
@@ -205,7 +205,7 @@ services:
       FIVETRAT_STORE_UPDATE_APP_ID: 5tratsmack
       FIVETRAT_STORE_UPDATE_CHANNEL: main
       FIVETRAT_INSTALL_REVISION: main-store
-      FIVETRAT_RELEASE_TAG: 0.10.27
+      FIVETRAT_RELEASE_TAG: 0.10.28
       FIVETRAT_OS_UPDATE_PROXY_BASE: http://host.docker.internal
       NETWORK_IP: "${NETWORK_IP}"
       BCH2_RPC_HOST: node-a

--- a/willitmod-dev-5tratsmack/umbrel-app.yml
+++ b/willitmod-dev-5tratsmack/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: willitmod-dev-5tratsmack
 category: altcoin
 name: 5tratSmack
-version: "0.10.27"
+version: "0.10.28"
 tagline: Home-miner 5TRAT node, wallet, solo pool and atomic trade lab
 description: >-
   Install and synchronize a complete 5TRAT node, create or restore an encrypted
@@ -10,12 +10,14 @@ description: >-
   use the atomic trade lab from one 5tratumOS app.
 
   This MAIN-channel Release Candidate has completed extended public-chain,
-  wallet, pool and trading tests. Version 0.10.27 adds the portable
-  browser-wallet bridge, clearer separation between mining electricity cost
-  and traded value, an in-app field guide, the latest named Blue, Pink and Gold
-  winners, and a strongest-proof Wall of Hash with one entry per personalised
-  coinbase name. Back up both the mining wallet and trading recovery file
-  before moving funds.
+  wallet, pool and trading tests. Version 0.10.28 is a routing hotfix for
+  5tratumOS. It reasserts the declared web UI on port 21226 after an update and
+  prevents the node JSON-RPC endpoint from being presented in the app window.
+  It also includes the portable browser-wallet bridge, clearer separation
+  between mining electricity cost and traded value, an in-app field guide, the
+  latest named Blue, Pink and Gold winners, and a strongest-proof Wall of Hash
+  with one entry per personalised coinbase name. Back up both the mining wallet
+  and trading recovery file before moving funds.
   The trade book uses the public
   Komodo DeFi Framework network through outbound peer connections; every atomic
   swap still requires the participating wallets to approve and settle it.


### PR DESCRIPTION
## What changed

- Publishes 5tratSmack 0.10.28 to MAIN.
- Reasserts the declared 21226 web UI route after an update.
- Uses the published amd64 and arm64 0.10.28 image manifest.

## Why

Some recent updates briefly exposed the 5TRAT node JSON-RPC endpoint in the app window while the web UI was starting. This package refresh reapplies the correct route and pairs with the 5tratumOS proxy-selection hotfix.

## Validation

- Manifest YAML parsed successfully.
- Image index contains linux/amd64 and linux/arm64.
- UI port remains 21226 and RPC remains isolated on 57576.