### PR TITLE
Release 5tratSmack 0.10.30 extranonce fix

### DIFF
--- a/willitmod-dev-5tratsmack/docker-compose.yml
+++ b/willitmod-dev-5tratsmack/docker-compose.yml
@@ -174,7 +174,7 @@ services:
       MINDIFF: "4096"
       STARTDIFF: "16384"
       MAXDIFF: "0"
-      NONCE2_LENGTH: "3"
+      NONCE2_LENGTH: "4"
       FIVETRAT_MINING_ACTIVATION_HEIGHT: "1000"
       DEV_FUND_ADDRESS: 5trat:qr7rg4z88tc34fr0z0mtkjc0c6s3knw5hce39q9evk
       DEV_FEE_PERCENT: "5"
@@ -196,7 +196,7 @@ services:
         condition: service_started
     environment:
       APP_ID: 5tratsmack
-      APP_VERSION: 0.10.29
+      APP_VERSION: 0.10.30
       APP_CHANNEL: MAIN
       APP_RELEASE_PHASE: RC1
       APP_PLATFORM: 5TRATUMOS

--- a/willitmod-dev-5tratsmack/umbrel-app.yml
+++ b/willitmod-dev-5tratsmack/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: willitmod-dev-5tratsmack
 category: altcoin
 name: 5tratSmack
-version: "0.10.29"
+version: "0.10.30"
 tagline: Home-miner 5TRAT node, wallet, solo pool and atomic trade lab
 description: >-
   Install and synchronize a complete 5TRAT node, create or restore an encrypted
@@ -10,7 +10,12 @@ description: >-
   use the atomic trade lab from one 5tratumOS app.
 
   This MAIN-channel Release Candidate has completed extended public-chain,
-  wallet, pool and trading tests. Version 0.10.29 fixes wallet restores that
+  wallet, pool and trading tests. Version 0.10.30 restores the four-byte
+  extranonce contract required by 5tratMux warm routing. Updating recreates
+  the bundled pool with the corrected setting while retaining the wallet RPC,
+  restore, rescan and trading fixes already present in 0.10.29.
+
+  Version 0.10.29 fixes wallet restores that
   could time out after the node had already created the restored database.
   Restore requests now have enough time to finish, are never replayed blindly,
   and a single interrupted restore can be verified and completed safely on the


### PR DESCRIPTION
## What changed

- Restores the bundled ckpool `NONCE2_LENGTH` setting to four bytes.
- Bumps the MAIN store package to 0.10.30.
- Retains the current 0.10.29 application image and its wallet RPC, restore, rescan, Trade and web-routing fixes.

## Why

The 0.10.29 MAIN recipe regressed to three bytes when the app was recreated. 5tratMux stable warm routing requires the previously agreed four-byte upstream extranonce contract.

## Validation

- Both modified YAML documents parse successfully.
- The store diff is limited to the 5tratSmack manifest and Compose recipe.
- The existing ckpool image already accepts `NONCE2_LENGTH=4`.
