### PR TITLE
Release AxeBCH 0.9.17

### DIFF
--- a/willitmod-dev-bch/docker-compose.yml
+++ b/willitmod-dev-bch/docker-compose.yml
@@ -217,7 +217,7 @@ services:
       - ${APP_DATA_DIR}/data/pool/www:/www
 
   app:
-    image: ghcr.io/willitmod/axebch-app-umbrel-dev:0.9.16
+    image: ghcr.io/willitmod/axebch-app-umbrel-dev:0.9.17
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 30s

--- a/willitmod-dev-bch/global-app.yml
+++ b/willitmod-dev-bch/global-app.yml
@@ -2,13 +2,17 @@ manifestVersion: 1
 id: willitmod-dev-bch
 category: bitcoin
 name: AxeBCH
-version: "0.9.16"
+version: "0.9.17"
 tagline: BCH node + solo pool
 description: >-
   RC1 RELEASE
 
   AxeBCH is functional, has successfully found blocks, and has completed
   extended DEV-channel pool and node testing.
+
+  Version 0.9.17 fixes Luck tracking on fresh installations and pools that have
+  not found their first block. Current-round effort now starts from the tracking
+  timestamp and switches automatically to the first real block anchor.
 
   Verify payout addresses before mining and send helpful feedback if anything
   behaves oddly.

--- a/willitmod-dev-bch/umbrel-app.yml
+++ b/willitmod-dev-bch/umbrel-app.yml
@@ -2,13 +2,17 @@ manifestVersion: 1
 id: willitmod-dev-bch
 category: bitcoin
 name: AxeBCH
-version: "0.9.16"
+version: "0.9.17"
 tagline: BCH node + solo pool
 description: >-
   RC1 RELEASE
 
   AxeBCH is functional, has successfully found blocks, and has completed
   extended DEV-channel pool and node testing.
+
+  Version 0.9.17 fixes Luck tracking on fresh installations and pools that have
+  not found their first block. Current-round effort now starts from the tracking
+  timestamp and switches automatically to the first real block anchor.
 
   Verify payout addresses before mining and send helpful feedback if anything
   behaves oddly.


### PR DESCRIPTION
Publishes AxeBCH 0.9.17 RC1.

- fixes Luck tracking on fresh installations before the first locally found block
- anchors round effort to the start of local tracking until a block is found
- labels the elapsed period accurately as Since tracking began
- preserves the normal Since last block behavior after the first solve
- uses the verified amd64/arm64 GHCR image