### PR TITLE
Release AxeXEC 0.1.15

### DIFF
--- a/willitmod-dev-xec/docker-compose.yml
+++ b/willitmod-dev-xec/docker-compose.yml
@@ -217,7 +217,7 @@ services:
       - ${APP_DATA_DIR}/data/pool/www:/www
 
   app:
-    image: ghcr.io/willitmod/axexec-app-umbrel-dev:0.1.14
+    image: ghcr.io/willitmod/axexec-app:0.1.15
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 30s

--- a/willitmod-dev-xec/umbrel-app.yml
+++ b/willitmod-dev-xec/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: willitmod-dev-xec
 category: bitcoin
 name: AxeXEC
-version: "0.1.14"
+version: "0.1.15"
 tagline: XEC node + solo pool
 description: >-
   RC1 RELEASE


### PR DESCRIPTION
## What changed

- bumps AxeXEC MAIN to `0.1.15`
- switches MAIN to the production `axexec-app:0.1.15` multi-architecture image

## Why

AxeXEC now publishes an explicit pool readiness contract. This prevents 5tratMux from incorrectly leaving a synchronized, reachable AxeXEC pool in `warming`.

## Verification

- Python syntax and readiness-contract checks passed
- equivalent DEV image deployed to 10.10.10.235
- AxeXEC reports `ready: true`, `stratum_online: true`, and `stratum.status: open`
- 5tratMux reports AxeXEC healthy at health 100
