### PR TITLE
Merge prefixed and prefixless worker identities

### DIFF
--- a/willitmod-dev-5tratsmack/docker-compose.yml
+++ b/willitmod-dev-5tratsmack/docker-compose.yml
@@ -187,7 +187,7 @@ services:
       - edge
 
   app:
-    image: ghcr.io/willitmod/5tratsmack-app:0.10.29
+    image: ghcr.io/willitmod/5tratsmack-app:0.10.31
     restart: unless-stopped
     depends_on:
       init_permissions:

--- a/willitmod-dev-5tratsmack/umbrel-app.yml
+++ b/willitmod-dev-5tratsmack/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: willitmod-dev-5tratsmack
 category: altcoin
 name: 5tratSmack
-version: "0.10.30"
+version: "0.10.31"
 tagline: Home-miner 5TRAT node, wallet, solo pool and atomic trade lab
 description: >-
   Install and synchronize a complete 5TRAT node, create or restore an encrypted
@@ -46,6 +46,11 @@ gallery:
 path: ""
 defaultUsername: ""
 defaultPassword: ""
+releaseNotes: >-
+  Workers using either the 5TRAT-prefixed or prefixless payout username now
+  appear as one combined worker entry in the app and Fleet Dashboard APIs.
+  Hashrate, shares and best-share data are merged without double-counting
+  duplicate worker names.
 widgets:
   - id: sync
     type: text-with-progress

--- a/willitmod-dev-axebch2/docker-compose.yml
+++ b/willitmod-dev-axebch2/docker-compose.yml
@@ -24,7 +24,7 @@ services:
         chmod -R ug+rwX /data/ui /data/node /data/pool || true
 
   app:
-    image: ghcr.io/willitmod/axebch2-app:0.2.0.1
+    image: ghcr.io/willitmod/axebch2-app:0.2.0.2
     user: "1000:1000"
     restart: unless-stopped
     depends_on:

--- a/willitmod-dev-axebch2/umbrel-app.yml
+++ b/willitmod-dev-axebch2/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: willitmod-dev-axebch2
 category: altcoin
 name: "AxeBCH2"
-version: "0.2.0.1"
+version: "0.2.0.2"
 tagline: BCH2 node + solo pool
 description: >-
   RC1 RELEASE
@@ -29,6 +29,11 @@ gallery:
 path: ""
 defaultUsername: ""
 defaultPassword: ""
+releaseNotes: >-
+  Workers using either coin-prefixed or prefixless payout usernames now appear
+  as one combined worker entry in the app and Fleet Dashboard APIs. Hashrate,
+  shares and best-share data are merged without double-counting duplicate
+  worker names.
 widgets:
   - id: "sync"
     type: "text-with-progress"

--- a/willitmod-dev-bc2/docker-compose.yml
+++ b/willitmod-dev-bc2/docker-compose.yml
@@ -150,7 +150,7 @@ services:
         fi
 
   app:
-    image: ghcr.io/willitmod/axebc2-app-umbrel-dev:0.1.8
+    image: ghcr.io/willitmod/axebc2-app-umbrel-dev:0.1.9
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 30s

--- a/willitmod-dev-bc2/umbrel-app.yml
+++ b/willitmod-dev-bc2/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: willitmod-dev-bc2
 category: bitcoin
 name: AxeBC2
-version: "0.1.8"
+version: "0.1.9"
 tagline: BC2 node + solo pool
 description: >-
   RC1 RELEASE
@@ -40,6 +40,11 @@ gallery:
 path: ""
 defaultUsername: ""
 defaultPassword: ""
+releaseNotes: >-
+  Workers using either coin-prefixed or prefixless payout usernames now appear
+  as one combined worker entry in the app and Fleet Dashboard APIs. Hashrate,
+  shares and best-share data are merged without double-counting duplicate
+  worker names.
 widgets:
   - id: "sync"
     type: "text-with-progress"

--- a/willitmod-dev-bch/docker-compose.yml
+++ b/willitmod-dev-bch/docker-compose.yml
@@ -217,7 +217,7 @@ services:
       - ${APP_DATA_DIR}/data/pool/www:/www
 
   app:
-    image: ghcr.io/willitmod/axebch-app-umbrel-dev:0.9.17
+    image: ghcr.io/willitmod/axebch-app-umbrel-dev:0.9.18
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 30s

--- a/willitmod-dev-bch/umbrel-app.yml
+++ b/willitmod-dev-bch/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: willitmod-dev-bch
 category: bitcoin
 name: AxeBCH
-version: "0.9.17"
+version: "0.9.18"
 tagline: BCH node + solo pool
 description: >-
   RC1 RELEASE
@@ -69,6 +69,11 @@ gallery:
 path: ""
 defaultUsername: ""
 defaultPassword: ""
+releaseNotes: >-
+  Workers using either coin-prefixed or prefixless payout usernames now appear
+  as one combined worker entry in the app and Fleet Dashboard APIs. Hashrate,
+  shares and best-share data are merged without double-counting duplicate
+  worker names.
 widgets:
   - id: "sync"
     type: "text-with-progress"

--- a/willitmod-dev-fracattack/docker-compose.yml
+++ b/willitmod-dev-fracattack/docker-compose.yml
@@ -216,7 +216,7 @@ services:
     entrypoint: ["/bin/sh", "/ckpool-entrypoint.sh"]
 
   app:
-    image: ghcr.io/willitmod/fracattack-app-umbrel-dev:0.1.3
+    image: ghcr.io/willitmod/fracattack-app-umbrel-dev:0.1.4
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 30s

--- a/willitmod-dev-fracattack/umbrel-app.yml
+++ b/willitmod-dev-fracattack/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: willitmod-dev-fracattack
 category: bitcoin
 name: FracAttack
-version: "0.1.3"
+version: "0.1.4"
 tagline: Fractal node + solo pool
 description: >-
   RC1 RELEASE
@@ -48,6 +48,11 @@ gallery:
 path: ""
 defaultUsername: ""
 defaultPassword: ""
+releaseNotes: >-
+  Workers using either coin-prefixed or prefixless payout usernames now appear
+  as one combined worker entry in the app and Fleet Dashboard APIs. Hashrate,
+  shares and best-share data are merged without double-counting duplicate
+  worker names.
 widgets:
   - id: "sync"
     type: "text-with-progress"

--- a/willitmod-dev-ppc/docker-compose.yml
+++ b/willitmod-dev-ppc/docker-compose.yml
@@ -232,7 +232,7 @@ services:
       - ${APP_DATA_DIR}/data/pool/cps/coins/peercoin.json:/app/coins/peercoin.json:ro
 
   app:
-    image: ghcr.io/willitmod/axeppc-app-umbrel-dev:0.2.30
+    image: ghcr.io/willitmod/axeppc-app-umbrel-dev:0.2.31
     user: "1000:1000"
     restart: unless-stopped
     stop_grace_period: 30s

--- a/willitmod-dev-ppc/umbrel-app.yml
+++ b/willitmod-dev-ppc/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: willitmod-dev-ppc
 category: altcoin
 name: AxePPC
-version: "0.2.30"
+version: "0.2.31"
 tagline: PPC node + solo pool
 description: >-
   RC1 RELEASE
@@ -35,6 +35,11 @@ gallery:
 path: ""
 defaultUsername: ""
 defaultPassword: ""
+releaseNotes: >-
+  Workers using either coin-prefixed or prefixless payout usernames now appear
+  as one combined worker entry in the app and Fleet Dashboard APIs. Hashrate,
+  shares and best-share data are merged without double-counting duplicate
+  worker names.
 widgets:
   - id: "sync"
     type: "text-with-progress"

--- a/willitmod-dev-xec/docker-compose.yml
+++ b/willitmod-dev-xec/docker-compose.yml
@@ -217,7 +217,7 @@ services:
       - ${APP_DATA_DIR}/data/pool/www:/www
 
   app:
-    image: ghcr.io/willitmod/axexec-app:0.1.15
+    image: ghcr.io/willitmod/axexec-app:0.1.16
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 30s

--- a/willitmod-dev-xec/umbrel-app.yml
+++ b/willitmod-dev-xec/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: willitmod-dev-xec
 category: bitcoin
 name: AxeXEC
-version: "0.1.15"
+version: "0.1.16"
 tagline: XEC node + solo pool
 description: >-
   RC1 RELEASE
@@ -62,6 +62,11 @@ gallery:
 path: ""
 defaultUsername: ""
 defaultPassword: ""
+releaseNotes: >-
+  Workers using either coin-prefixed or prefixless payout usernames now appear
+  as one combined worker entry in the app and Fleet Dashboard APIs. Hashrate,
+  shares and best-share data are merged without double-counting duplicate
+  worker names.
 widgets:
   - id: "sync"
     type: "text-with-progress"


### PR DESCRIPTION
## What changed

Updates every affected ckpool node app currently published in the MAIN store so coin-prefixed and prefixless payout usernames are combined into one worker identity.

Apps: AxeBC2, AxeBCH2, AxeBCH, AxePPC, AxeXEC, FracAttack and 5tratSmack. AxeBTC remains DEV-only.

AxeDGB and PowPow are unchanged because they use Miningcore/API worker records rather than ckpool payout-keyed files.

## Validation

- all referenced GHCR tags exist
- every image contains linux/amd64 and linux/arm64 manifests
- all YAML parses successfully
- release notes included for each app
- 5tratSmack NONCE2_LENGTH remains 4