### PR TITLE
Release AxeBCH2 0.2.0.3

### DIFF
--- a/willitmod-dev-axebch2/docker-compose.yml
+++ b/willitmod-dev-axebch2/docker-compose.yml
@@ -24,7 +24,7 @@ services:
         chmod -R ug+rwX /data/ui /data/node /data/pool || true
 
   app:
-    image: ghcr.io/willitmod/axebch2-app:0.2.0.2
+    image: ghcr.io/willitmod/axebch2-app:0.2.0.3
     user: "1000:1000"
     restart: unless-stopped
     depends_on:
@@ -44,7 +44,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
       APP_ID: "willitmod-dev-axebch2"
-      APP_VERSION: "0.2.0.1"
+      APP_VERSION: "0.2.0.3"
       APP_CHANNEL: "RC1"
       APP_RELEASE_PHASE: "RC"
       APP_SELF_RESTART_ENABLED: "1"

--- a/willitmod-dev-axebch2/umbrel-app.yml
+++ b/willitmod-dev-axebch2/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: willitmod-dev-axebch2
 category: altcoin
 name: "AxeBCH2"
-version: "0.2.0.2"
+version: "0.2.0.3"
 tagline: BCH2 node + solo pool
 description: >-
   RC1 RELEASE
@@ -30,10 +30,9 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 releaseNotes: >-
-  Workers using either coin-prefixed or prefixless payout usernames now appear
-  as one combined worker entry in the app and Fleet Dashboard APIs. Hashrate,
-  shares and best-share data are merged without double-counting duplicate
-  worker names.
+  Corrects stale version metadata from 0.2.0.2 so the store, image, app UI, API
+  and support check-in now consistently report 0.2.0.3. Includes the worker
+  identity compatibility fix from the previous release.
 widgets:
   - id: "sync"
     type: "text-with-progress"


### PR DESCRIPTION
Publishes AxeBCH2 0.2.0.3 and removes the stale APP_VERSION override that made the 0.2.0.2 image report itself as 0.2.0.1.\n\nVerified the published image is multi-architecture (amd64/arm64) and reports embedded version 0.2.0.3.