### PR TITLE
Release AxeLive 1.4.3 MAIN proxy hotfix

### DIFF
--- a/willitmod-axelive/docker-compose.yml
+++ b/willitmod-axelive/docker-compose.yml
@@ -3,11 +3,11 @@ version: "3.7"
 services:
   app_proxy:
     environment:
-      APP_HOST: willitmod-dev-axelive_server_1
+      APP_HOST: willitmod-axelive_server_1
       APP_PORT: 5210
 
   server:
-    image: ghcr.io/willitmod/axelive:v1.4.2
+    image: ghcr.io/willitmod/axelive:v1.4.3
     restart: on-failure
     stop_grace_period: 30s
     init: true

--- a/willitmod-axelive/umbrel-app.yml
+++ b/willitmod-axelive/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: willitmod-axelive
 category: bitcoin
 name: AxeLive
-version: "1.4.2"
+version: "1.4.3"
 tagline: Real-time miner monitoring and thermal control
 icon: https://raw.githubusercontent.com/WillItMod/umbrel-community-store/main/willitmod-axelive/icon.png
 description: >-
@@ -27,5 +27,6 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 releaseNotes: >-
-  v1.4.2: Promotes the tested DEV build to MAIN, improves IP scan cancellation when offline miners are slow to respond, and fixes a Nano 3/3S thermal-model edge case that could silently stop fan-learning updates.
+  v1.4.3: Fixes the MAIN-channel Umbrel proxy route so AxeLive opens normally
+  after updating. The AxeLive server and saved miner data are unchanged.
 submitter: WillItMod


### PR DESCRIPTION
## What changed

- Corrects the MAIN-channel Umbrel proxy target from the DEV container name to the MAIN AxeLive container.
- Bumps the MAIN release to 1.4.3 and references the published multi-architecture v1.4.3 image.

## Root cause

The 1.4.2 DEV-to-MAIN promotion retained `willitmod-dev-axelive_server_1` as `APP_HOST`. MAIN creates `willitmod-axelive_server_1`, so Umbrel could not route the iframe to the healthy AxeLive server and reported a network error.

## Validation

- Both YAML files parse successfully.
- `git diff --check` passes.
- The v1.4.3 image is published for AMD64 and ARM64.
- The underlying AxeLive image starts successfully and returns HTTP 200 on port 5210.

Saved AxeLive data is unchanged.