### PR TITLE
Release 5tratSmack 0.11.7 to MAIN

### DIFF
--- a/willitmod-dev-5tratsmack/5tratstore-app.yml
+++ b/willitmod-dev-5tratsmack/5tratstore-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: willitmod-dev-5tratsmack
 category: altcoin
 name: 5tratSmack
-version: "0.11.6"
+version: "0.11.7"
 tagline: Home-miner 5TRAT node, wallet, solo pool and atomic trade lab
 description: >-
   Install and synchronize a complete 5TRAT node, create or restore an encrypted
@@ -41,7 +41,8 @@ releaseNotes: >-
   loop that could survive an app reinstall. Only the rebuildable txindex is
   quarantined; wallets, blocks, chainstate, pool and trading data are retained.
   Repeated recovery is rate-limited and later healthy startups supersede old
-  errors.
+  errors. Restores live 5tratMux hardware identity and active-route hashrate
+  telemetry with stale-route, standby and worker-alias protection.
 widgets:
   - id: sync
     type: text-with-progress

--- a/willitmod-dev-5tratsmack/5tratstore-app.yml
+++ b/willitmod-dev-5tratsmack/5tratstore-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: willitmod-dev-5tratsmack
 category: altcoin
 name: 5tratSmack
-version: "0.11.5"
+version: "0.11.6"
 tagline: Home-miner 5TRAT node, wallet, solo pool and atomic trade lab
 description: >-
   Install and synchronize a complete 5TRAT node, create or restore an encrypted
@@ -37,11 +37,11 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 releaseNotes: >-
-  Fixes iPhone and iPad confirmation dialogs so trade approval buttons remain
-  visible in portrait and landscape. Long trade, wallet, backup, explorer,
-  search, block-win and authentication popups now follow the live viewport,
-  respect device safe areas and scroll independently. Existing wallet,
-  blockchain, pool and trading data are retained during the update.
+  Automatically recovers from the specific damaged transaction-index startup
+  loop that could survive an app reinstall. Only the rebuildable txindex is
+  quarantined; wallets, blocks, chainstate, pool and trading data are retained.
+  Repeated recovery is rate-limited and later healthy startups supersede old
+  errors.
 widgets:
   - id: sync
     type: text-with-progress

--- a/willitmod-dev-5tratsmack/docker-compose.yml
+++ b/willitmod-dev-5tratsmack/docker-compose.yml
@@ -17,8 +17,6 @@ services:
       APP_HOST: 5tratsmack-app
       APP_PORT: 3000
       JWT_SECRET: "${JWT_SECRET}"
-    networks:
-      - umbrel_main_network
 
   init_permissions:
     image: alpine:3.22.1
@@ -94,7 +92,7 @@ services:
       retries: 12
 
   node-a:
-    image: ghcr.io/willitmod/5tratsmack-core:0.11.1
+    image: ghcr.io/willitmod/5tratsmack-core:0.11.2
     restart: unless-stopped
     stop_grace_period: 2m
     depends_on:
@@ -187,7 +185,7 @@ services:
       - edge
 
   app:
-    image: ghcr.io/willitmod/5tratsmack-app:0.11.5
+    image: ghcr.io/willitmod/5tratsmack-app:0.11.6
     restart: unless-stopped
     depends_on:
       init_permissions:
@@ -196,7 +194,7 @@ services:
         condition: service_started
     environment:
       APP_ID: 5tratsmack
-      APP_VERSION: 0.11.5
+      APP_VERSION: 0.11.6
       APP_CHANNEL: MAIN
       APP_RELEASE_PHASE: RC1
       APP_PLATFORM: 5TRATUMOS
@@ -205,7 +203,7 @@ services:
       FIVETRAT_STORE_UPDATE_APP_ID: 5tratsmack
       FIVETRAT_STORE_UPDATE_CHANNEL: main
       FIVETRAT_INSTALL_REVISION: main-store
-      FIVETRAT_RELEASE_TAG: 0.11.5
+      FIVETRAT_RELEASE_TAG: 0.11.6
       FIVETRAT_OS_UPDATE_PROXY_BASE: http://host.docker.internal
       NETWORK_IP: "${NETWORK_IP}"
       BCH2_RPC_HOST: node-a
@@ -238,9 +236,6 @@ services:
     networks:
       chain:
       edge:
-      umbrel_main_network:
-        aliases:
-          - 5tratsmack-app
     extra_hosts:
       - "host.docker.internal:host-gateway"
     healthcheck:
@@ -256,6 +251,3 @@ networks:
   chain:
     internal: true
   edge:
-  umbrel_main_network:
-    external: true
-    name: umbrel_main_network

--- a/willitmod-dev-5tratsmack/docker-compose.yml
+++ b/willitmod-dev-5tratsmack/docker-compose.yml
@@ -185,7 +185,7 @@ services:
       - edge
 
   app:
-    image: ghcr.io/willitmod/5tratsmack-app:0.11.6
+    image: ghcr.io/willitmod/5tratsmack-app:0.11.7
     restart: unless-stopped
     depends_on:
       init_permissions:
@@ -194,7 +194,7 @@ services:
         condition: service_started
     environment:
       APP_ID: 5tratsmack
-      APP_VERSION: 0.11.6
+      APP_VERSION: 0.11.7
       APP_CHANNEL: MAIN
       APP_RELEASE_PHASE: RC1
       APP_PLATFORM: 5TRATUMOS
@@ -203,7 +203,8 @@ services:
       FIVETRAT_STORE_UPDATE_APP_ID: 5tratsmack
       FIVETRAT_STORE_UPDATE_CHANNEL: main
       FIVETRAT_INSTALL_REVISION: main-store
-      FIVETRAT_RELEASE_TAG: 0.11.6
+      FIVETRAT_RELEASE_TAG: 0.11.7
+      FIVETRAT_MUX_IDENTITY_URL: http://172.17.0.1:21222/api/integrations/workers
       FIVETRAT_OS_UPDATE_PROXY_BASE: http://host.docker.internal
       NETWORK_IP: "${NETWORK_IP}"
       BCH2_RPC_HOST: node-a


### PR DESCRIPTION
Publishes 5tratSmack 0.11.7 to the MAIN store with txindex auto-recovery and restored live 5tratMux hardware/active-route hashrate telemetry. Validated on 10.10.10.235.