### PR TITLE
Release AxeBTC BIP-110 option to MAIN

### DIFF
--- a/willitmod-btc/5tratstore-app.yml
+++ b/willitmod-btc/5tratstore-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: willitmod-btc
 category: bitcoin
 name: AxeBTC
-version: "0.7.82.8"
+version: "0.7.82.11"
 tagline: BTC node + solo pool
 description: >-
   RC1 RELEASE
@@ -28,8 +28,9 @@ description: >-
     - Blockchains can carry arbitrary data (e.g. via `OP_RETURN`). That’s not unique to any one chain.
     - Set your payout address in the app Settings tab.
     - Pool settings apply automatically; miners may briefly reconnect after saving.
-    - On first launch you must pick Bitcoin Core vs Knots before sync starts.
-    - Switching Core/Knots triggers an in-app migration and can take a while; avoid restarting the app or powering off the host while it migrates.
+    - On first launch you choose Bitcoin Core, standard Knots, or the explicit BIP-110/RDTS Knots option.
+    - Core and standard Knots follow established Bitcoin. BIP-110/RDTS can follow a minority chain and requires a separate risk confirmation.
+    - RDTS chain data is isolated from the established-chain data. Switching implementations can take a while; avoid restarting or powering off while it migrates.
     - BTC payout addresses support bech32 (`bc1...`) and legacy (`1...` / `3...`). Bitcoin Cash CashAddr (`q...` / `p...`) is not supported.
 developer: WillItMod
 website: https://github.com/WillItMod/5tratStore-main
@@ -47,6 +48,11 @@ gallery:
 path: ""
 defaultUsername: ""
 defaultPassword: ""
+releaseNotes: >-
+  Adds an explicit optional BIP-110/RDTS Knots node profile with a prominent
+  risk warning and required acknowledgement. Bitcoin Core 30.3 and standard
+  Knots 29.3 remain established-chain choices. RDTS uses separate chain data,
+  preventing it from contaminating the normal Core/Knots chainstate.
 widgets:
   - id: "sync"
     type: "text-with-progress"
@@ -81,4 +87,7 @@ backupIgnore:
   - data/node/blocks
   - data/node/chainstate
   - data/node/indexes
+  - data/node-rdts/blocks
+  - data/node-rdts/chainstate
+  - data/node-rdts/indexes
 submitter: WillItMod

--- a/willitmod-btc/docker-compose.yml
+++ b/willitmod-btc/docker-compose.yml
@@ -6,13 +6,12 @@ services:
       APP_HOST: axebtc-app
       APP_PORT: 3000
       JWT_SECRET: "${JWT_SECRET}"
-    networks:
-      - umbrel_main_network
 
   init:
     image: alpine:3.22.1
     volumes:
       - ${APP_DATA_DIR}/data:/data
+      - ${APP_DATA_DIR}/data/node-rdts:/data-rdts
       - ${APP_DATA_DIR}:/appdata
       - ${APP_DATA_DIR}/data/templates:/data/templates:rw
     environment:
@@ -47,7 +46,8 @@ services:
           mv "$$tmp" "$$envfile"
         fi
 
-        mkdir -p /data/node /data/pool/config /data/pool/www/pool /data/pool/www/users
+        mkdir -p /data/node /data-rdts /data/pool/config /data/pool/www/pool /data/pool/www/users
+        chown 1000:1000 /data-rdts || true
         # Ensure template scripts are executable (Windows checkouts can lose +x).
         chmod +x /data/templates/bitcoind-entrypoint.sh /data/templates/ckpool-entrypoint.sh 2>/dev/null || true
         chown 1000:1000 /data/templates/bitcoind-entrypoint.sh /data/templates/ckpool-entrypoint.sh 2>/dev/null || true
@@ -56,7 +56,7 @@ services:
         # Older installs may have persisted an AxeBTCF-era ckpool.conf.template (merged-mining/Fractal).
         # Because templates live in the persistent /data volume, store updates do not automatically replace them.
         #
-        # NOTE: avoid embedding a full JSON template directly in this command block because 5tratumos/umbrel
+        # NOTE: avoid embedding a full JSON template directly in this command block because 5tratumOS
         # tooling rewrites docker-compose.yml and can choke on lots of unescaped quotes.
         if [ -f /data/templates/ckpool.conf.template ]; then
           if grep -q '"auxd"' /data/templates/ckpool.conf.template; then
@@ -144,7 +144,7 @@ services:
         fi
 
   bitcoind:
-    image: ghcr.io/willitmod/axebtc-bitcoind-switch:0.7.44
+    image: ghcr.io/willitmod/axebtc-bitcoind-switch:0.7.47
     user: "1000:1000"
     restart: unless-stopped
     stop_grace_period: 15m30s
@@ -153,6 +153,7 @@ services:
         condition: service_completed_successfully
     volumes:
       - ${APP_DATA_DIR}/data/node:/data
+      - ${APP_DATA_DIR}/data/node-rdts:/data-rdts
       - ${APP_DATA_DIR}/data/templates/bitcoind-entrypoint.sh:/bitcoind-entrypoint.sh:ro
     entrypoint: ["/bin/sh", "/bitcoind-entrypoint.sh"]
     healthcheck:
@@ -178,7 +179,7 @@ services:
     entrypoint: ["/bin/sh", "/ckpool-entrypoint.sh"]
 
   app:
-    image: ghcr.io/willitmod/axebtc-app-umbrel-dev:0.7.82.8
+    image: ghcr.io/willitmod/axebtc-app-5tratumos:0.7.82.11
     user: "1000:1000"
     restart: on-failure
     stop_grace_period: 30s
@@ -187,9 +188,6 @@ services:
       - ckpool
     networks:
       default:
-        aliases:
-          - axebtc-app
-      umbrel_main_network:
         aliases:
           - axebtc-app
     volumes:
@@ -202,13 +200,11 @@ services:
       CKPOOL_STATUS_DIR: "/data/pool/www/pool"
       CKPOOL_STRATUM_HOST: "ckpool"
       CKPOOL_STRATUM_PORT: "3333"
-      APP_CHANNEL: "RC1"
+      APP_CHANNEL: "MAIN"
       APP_VERSION_SUFFIX: ""
-      BITCOIND_IMAGE: "ghcr.io/willitmod/axebtc-bitcoind-switch:0.7.44"
+      BTC_CORE_VERSION: "30.3"
+      BTC_KNOTS_VERSION: "29.3.knots20260507"
+      BTC_KNOTS_RDTS_VERSION: "29.3.knots20260508"
+      BITCOIND_IMAGE: "ghcr.io/willitmod/axebtc-bitcoind-switch:0.7.47"
       CKPOOL_IMAGE: "ghcr.io/willitmod/docker-ckpool-solo:590fb2a"
       STATIC_DIR: "/app/static"
-
-networks:
-  umbrel_main_network:
-    external: true
-    name: umbrel_main_network

--- a/willitmod-btc/exports.sh
+++ b/willitmod-btc/exports.sh
@@ -1,17 +1,17 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Umbrel's auth-server signs tokens with JWT_SECRET (not UMBREL_AUTH_SECRET).
+# The platform auth server signs tokens with JWT_SECRET.
 # In some update/restart flows (especially manual SSH updates), JWT_SECRET may not
 # be exported into the app environment, which causes app_proxy to reject logins.
 #
 # If it's missing, read it from the running `auth` container so app_proxy can
-# validate Umbrel JWTs reliably.
+# validate platform JWTs reliably.
 
 if [[ -z "${JWT_SECRET:-}" ]] && command -v docker >/dev/null 2>&1; then
   jwt_secret_from_auth=""
 
-  for auth_container in auth umbrel-auth umbrel_auth; do
+  for auth_container in auth 5tratumos-auth 5tratumos_auth; do
     jwt_secret_from_auth="$(
       docker inspect --format '{{range .Config.Env}}{{println .}}{{end}}' "${auth_container}" 2>/dev/null \
         | sed -n 's/^JWT_SECRET=//p' \
@@ -27,5 +27,5 @@ if [[ -z "${JWT_SECRET:-}" ]] && command -v docker >/dev/null 2>&1; then
   fi
 fi
 
-# Last-resort fallback (keeps proxy from crashing, but won't match Umbrel auth tokens).
+# Last-resort fallback (keeps proxy from crashing, but won't match platform auth tokens).
 export JWT_SECRET="${JWT_SECRET:-DEADBEEF}"


### PR DESCRIPTION
Stages AxeBTC app 0.7.82.11 and node 0.7.47. Adds an explicit opt-in BIP-110/RDTS Knots profile with a separate data directory and acknowledgement gate; Core and standard Knots remain unchanged established-chain choices. All three profiles passed isolated functional testing. Source dependency: WillItMod/AxeBTC_Build#2. Merge after DEV package/deployment validation.