### PR TITLE
Fix 5tratSmack proxy connectivity on Umbrel

### DIFF
--- a/willitmod-dev-5tratsmack/5tratstore-app.yml
+++ b/willitmod-dev-5tratsmack/5tratstore-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: willitmod-dev-5tratsmack
 category: altcoin
 name: 5tratSmack
-version: "0.11.7"
+version: "0.11.8"
 tagline: Home-miner 5TRAT node, wallet, solo pool and atomic trade lab
 description: >-
   Install and synchronize a complete 5TRAT node, create or restore an encrypted
@@ -37,12 +37,10 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 releaseNotes: >-
-  Automatically recovers from the specific damaged transaction-index startup
-  loop that could survive an app reinstall. Only the rebuildable txindex is
-  quarantined; wallets, blocks, chainstate, pool and trading data are retained.
-  Repeated recovery is rate-limited and later healthy startups supersede old
-  errors. Restores live 5tratMux hardware identity and active-route hashrate
-  telemetry with stale-route, standby and worker-alias protection.
+  Restores the application proxy connection on Umbrel while retaining native
+  5tratumOS compatibility. Existing wallets, blockchain, pool and trading data
+  are retained. Includes the 0.11.7 transaction-index recovery and 5tratMux
+  telemetry fixes.
 widgets:
   - id: sync
     type: text-with-progress

--- a/willitmod-dev-5tratsmack/docker-compose.yml
+++ b/willitmod-dev-5tratsmack/docker-compose.yml
@@ -17,6 +17,8 @@ services:
       APP_HOST: 5tratsmack-app
       APP_PORT: 3000
       JWT_SECRET: "${JWT_SECRET}"
+    networks:
+      - edge
 
   init_permissions:
     image: alpine:3.22.1
@@ -194,7 +196,7 @@ services:
         condition: service_started
     environment:
       APP_ID: 5tratsmack
-      APP_VERSION: 0.11.7
+      APP_VERSION: 0.11.8
       APP_CHANNEL: MAIN
       APP_RELEASE_PHASE: RC1
       APP_PLATFORM: 5TRATUMOS
@@ -203,7 +205,7 @@ services:
       FIVETRAT_STORE_UPDATE_APP_ID: 5tratsmack
       FIVETRAT_STORE_UPDATE_CHANNEL: main
       FIVETRAT_INSTALL_REVISION: main-store
-      FIVETRAT_RELEASE_TAG: 0.11.7
+      FIVETRAT_RELEASE_TAG: 0.11.8
       FIVETRAT_MUX_IDENTITY_URL: http://172.17.0.1:21222/api/integrations/workers
       FIVETRAT_OS_UPDATE_PROXY_BASE: http://host.docker.internal
       NETWORK_IP: "${NETWORK_IP}"
@@ -237,6 +239,8 @@ services:
     networks:
       chain:
       edge:
+        aliases:
+          - 5tratsmack-app
     extra_hosts:
       - "host.docker.internal:host-gateway"
     healthcheck:

--- a/willitmod-dev-5tratsmack/umbrel-app.yml
+++ b/willitmod-dev-5tratsmack/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: willitmod-dev-5tratsmack
 category: altcoin
 name: 5tratSmack
-version: "0.11.7"
+version: "0.11.8"
 tagline: Home-miner 5TRAT node, wallet, solo pool and atomic trade lab
 description: >-
   Install and synchronize a complete 5TRAT node, create or restore an encrypted
@@ -37,12 +37,10 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 releaseNotes: >-
-  Automatically recovers from the specific damaged transaction-index startup
-  loop that could survive an app reinstall. Only the rebuildable txindex is
-  quarantined; wallets, blocks, chainstate, pool and trading data are retained.
-  Repeated recovery is rate-limited and later healthy startups supersede old
-  errors. Restores live 5tratMux hardware identity and active-route hashrate
-  telemetry with stale-route, standby and worker-alias protection.
+  Restores the application proxy connection on Umbrel while retaining native
+  5tratumOS compatibility. Existing wallets, blockchain, pool and trading data
+  are retained. Includes the 0.11.7 transaction-index recovery and 5tratMux
+  telemetry fixes.
 widgets:
   - id: sync
     type: text-with-progress


### PR DESCRIPTION
Fixes the 0.11.7 regression where `app_proxy` could not resolve `5tratsmack-app` after the Umbrel-specific shared-network stanza was removed.

The proxy and application now share the existing portable `edge` network, and the application advertises the expected `5tratsmack-app` alias there. This works without restoring Umbrel-specific paths or external-network dependencies.

Bumps the store package to 0.11.8 so affected installations are offered the corrected recipe. The application container remains the tested 0.11.7 image; no wallet or application data paths change.

Validation:
- Both manifests parse and report 0.11.8
- Docker Compose renders successfully with the platform-provided proxy service
- `git diff --check` passes